### PR TITLE
announcements save to server

### DIFF
--- a/client/src/components/manager/AnnouncementManager.jsx
+++ b/client/src/components/manager/AnnouncementManager.jsx
@@ -42,16 +42,29 @@ class AnnouncementManager extends React.Component {
   submitAnnouncement() {
     if (this.state.modalAnnouncement) {
       // ajax patch..
-      // client side change. this is ugly. please let me know if there's a better way. -marcus
-      var announcements = this.state.announcements.map(announcement => {
-        if (announcement.id === this.state.modalAnnouncement.id) {
-          announcement.message = this.state.modalMessage;
-          announcement.status = this.state.modalStatus;
+      $.ajax({
+        url: `/announcements/${this.state.modalAnnouncement.id}`,
+        method: 'PATCH',
+        data: {
+            message: this.state.modalMessage,
+            status: this.state.modalStatus
+        },
+        success: (ann) => {
+          // might even want to use the data from this new ann.
+          var announcements = this.state.announcements.map(announcement => {
+            if (announcement.id === this.state.modalAnnouncement.id) {
+              announcement.message = this.state.modalMessage;
+              announcement.status = this.state.modalStatus;
+            }
+            return announcement;
+          });
+          this.setState({announcements: announcements})
+        },
+        error: (err) => {
+          console.log('error patching. ', err);
         }
-        return announcement;
       });
-
-      this.setState({announcements: announcements})
+      // client side change. this seems ugly. please let me know if there's a better way. -marcus
     } else {
       // post.
     }
@@ -157,8 +170,6 @@ class AnnouncementManager extends React.Component {
             </table>
           </div>
         </div>
-        {this.state.modalMessage}
-        {this.state.modalStatus}
       </div>
     );
   }

--- a/client/src/components/manager/AnnouncementManager.jsx
+++ b/client/src/components/manager/AnnouncementManager.jsx
@@ -7,7 +7,7 @@ class AnnouncementManager extends React.Component {
     super(props);
     this.state = {
       announcements: [],
-      modalMessage: 'okkaaa',
+      modalMessage: '',
       modalStatus: '',
       modalAnnouncement: null
     };

--- a/client/src/components/manager/AnnouncementManager.jsx
+++ b/client/src/components/manager/AnnouncementManager.jsx
@@ -26,8 +26,6 @@ class AnnouncementManager extends React.Component {
         modalMessage: announcement.message,
         modalStatus: announcement.status}
       );
-      console.log('announcement set to: ', announcement);
-      console.log('modalMessage: ', this.state.modalMessage);
     } else {
     // if not, created a new announcement, setState
       this.setState(
@@ -35,7 +33,6 @@ class AnnouncementManager extends React.Component {
         modalMessage: '',
         modalStatus: ''}
       );
-      console.log('no announcement or something');
     }
   }
 
@@ -82,7 +79,6 @@ class AnnouncementManager extends React.Component {
       method: 'GET',
       success: (announcements) => {
         this.state.announcements = announcements;
-        console.log(announcements);
       },
       error:  (err) => {
         console.log('err', err);
@@ -98,7 +94,6 @@ class AnnouncementManager extends React.Component {
 
   changeModalStatus(status) {
     this.setState({modalStatus: status});
-    console.log('changed status to: ', status);
   }
 
   render() {

--- a/server/index.js
+++ b/server/index.js
@@ -187,13 +187,21 @@ app.post('/restaurant/:id/announcements', (req, res) => {
 });
 
 app.patch('/announcements/:id', (req, res) => {
+
   var message = req.body.message;
   var status = req.body.status;
-
   db.Announcement.findOne({where: {id: req.params.id}})
-  .then(ann => ann.update({message: message, status: status}))
+  .then(ann => {
+    if (ann.restaurantId !== req.user.restaurantId) {
+      res.status(401).send('nope')
+      throw('not authenticated');}
+    else return ann.update({message: message, status: status})
+  })
   .then(db.Announcement.findOne({where: {id: req.params.id}}))
-  .then(updatedAnn => res.json(updatedAnn));
+  .then(updatedAnn => res.json(updatedAnn))
+  .catch(err => {
+    console.log('err with patching announcement:', err)
+    res.status(400).send('something went wrong')});
 });
 
 

--- a/server/index.js
+++ b/server/index.js
@@ -186,6 +186,16 @@ app.post('/restaurant/:id/announcements', (req, res) => {
     }
 });
 
+app.patch('/announcements/:id', (req, res) => {
+  var message = req.body.message;
+  var status = req.body.status;
+
+  db.Announcement.findOne({where: {id: req.params.id}})
+  .then(ann => ann.update({message: message, status: status}))
+  .then(db.Announcement.findOne({where: {id: req.params.id}}))
+  .then(updatedAnn => res.json(updatedAnn));
+});
+
 
 //drop database and add dummy data
 app.post('/dummydata', (req, res) => {


### PR DESCRIPTION
server handles PATCH requests.
client can send PATCH requests.
server requires authentication so you can't edit other restaurants announcements.

note: response sends the updated announcement row. might refactor the current code to change the state to that updated announcement instead of just going by the state. or just skip the extra lookup at the end and just send a 200 response.